### PR TITLE
implement environment variables for degauss metadata; closes #24

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dht
 Title: A Collection of Functions to Assist Building DeGAUSS Containers
-Version: 0.2.0
+Version: 0.3.0
 Authors@R: c(
     person(given = "Erika",
            family = "Rasnick",

--- a/R/greeting.R
+++ b/R/greeting.R
@@ -1,5 +1,10 @@
 #' display DeGUASS greeting message in console
 #'
+#' if not supplied as arguments, greeting-specific values
+#' (geomarker_name, version, description) are read in from the environment variables
+#' specified in the Dockerfile and made available when running the container;
+#' these include `degauss_name`, `degauss_version`, and `degauss_description`
+#'
 #' @export
 #' @param geomarker_name name of the geomarker, must be the name used in the degauss.org url
 #' @param version container version number as a character string
@@ -13,12 +18,14 @@
 #' as well as links to more information about the specific geomarker,
 #' DeGAUSS in general for troubleshooting, and the DeGUASS user RedCap survey.
 
-greeting <- function(geomarker_name, version, description) {
-  cli::cli_h1('Wecome to DeGAUSS!')
-  cli::cli_alert_info('You are using the {geomarker_name} container, version {version}.', wrap = TRUE)
-  cli::cli_text('This container {description}.')
-  cli::cli_text('For more information about the {geomarker_name} container,
-                visit {.url https://degauss.org/{geomarker_name}/}')
-  cli::cli_text('For DeGAUSS troubleshooting, visit {.url https://degauss.org/}')
-  cli::cli_text('To help us improve DeGAUSS, please take our user survey at {.url https://degauss.org/survey}')
+greeting <- function(geomarker_name = Sys.getenv("degauss_name"),
+                     version = Sys.getenv("degauss_version"),
+                     description = Sys.getenv("degauss_description")) {
+  cli::cli_h1("Wecome to DeGAUSS!")
+  cli::cli_alert_info("You are using the {geomarker_name} container, version {version}.", wrap = TRUE)
+  cli::cli_text("This container {description}.")
+  cli::cli_text("For more information about the {geomarker_name} container,
+                visit {.url https://degauss.org/{geomarker_name}/}")
+  cli::cli_text("For DeGAUSS troubleshooting, visit {.url https://degauss.org/}")
+  cli::cli_text("To help us improve DeGAUSS, please take our user survey at {.url https://degauss.org/survey}")
 }

--- a/R/use_degauss_files.R
+++ b/R/use_degauss_files.R
@@ -23,7 +23,7 @@
 use_degauss_container <- function(geomarker = getwd(), version = "0.1.0", ...) {
   use_degauss_entrypoint(geomarker = geomarker, version = version, ...)
   use_degauss_readme(geomarker = geomarker, version = version, ...)
-  use_degauss_dockerfile(geomarker = geomarker, ...)
+  use_degauss_dockerfile(geomarker = geomarker, version = version, ...)
   use_degauss_dockerignore(geomarker = geomarker, ...)
   use_degauss_license(geomarker = geomarker, ...)
   use_degauss_makefile(geomarker = geomarker, ...)
@@ -45,7 +45,7 @@ render_degauss_template <- function(read_from, write_to, data = list(), overwrit
 
 #' @export
 #' @rdname use_degauss_container
-use_degauss_dockerfile <- function(geomarker = getwd(), ...) {
+use_degauss_dockerfile <- function(geomarker = getwd(), version, ...) {
   r_version <- paste(getRversion(), sep = ".")
   if (r_version < "4.0.0") {
     cli::cli_abort("The r-ver container framework and RSPM repo only work with R versions 4.0 or greater.")
@@ -68,7 +68,9 @@ use_degauss_dockerfile <- function(geomarker = getwd(), ...) {
     write_to = dest_path,
     data = list(
       "r_version" = r_version,
-      "renv_version" = renv_version
+      "renv_version" = renv_version,
+      "name" = basename(geomarker_path),
+      "version" = version
     ),
     ...
   )

--- a/R/write_geomarker_file.R
+++ b/R/write_geomarker_file.R
@@ -5,8 +5,10 @@
 #' @param raw_data original unnested input data, defaults to NULL (for use when
 #'                 nest_df = FALSE in read_lat_lon_csv)
 #' @param filename name of input file, probably opt$filename if inside container
-#' @param geomarker_name name of the geomarker, must be the name used in the degauss.org url
-#' @param version container version number as a character string
+#' @param geomarker_name name of the geomarker, must be the name used in the degauss.org url;
+#' defaults to degauss environment variable `degauss_name`
+#' @param version container version number as a character string; defaults to degauss environment
+#' variable `degauss_version`
 #' @return output file is written to working directory
 #' @examples
 #' \dontrun{
@@ -15,7 +17,11 @@
 #'            geomarker='roads', version='0.4')
 #' }
 
-write_geomarker_file <- function(d, raw_data = NULL, filename, geomarker_name, version) {
+write_geomarker_file <- function(d,
+                                 raw_data = NULL,
+                                 filename,
+                                 geomarker_name = Sys.getenv("degauss_name"),
+                                 version = Sys.getenv("degauss_version")) {
   if (!is.null(raw_data)) {
     d <- tidyr::unnest(d, cols = c(.rows))
     if('sf' %in% class(d)) d <- sf::st_drop_geometry(d)

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 [![R build status](https://github.com/degauss-org/dht/workflows/R-CMD-check/badge.svg)](https://github.com/degauss-org/dht/actions)
 <!-- badges: end -->
 
-`dht` (**d**egauss **h**elper **t**ools) is a collection of tools used to develop and run [DeGAUSS](https://degauss.org) containers.
+(**d**egauss **h**elper **t**ools) are used to develop and run [DeGAUSS](https://degauss.org) containers.
 
 ## Installation
 
@@ -34,13 +34,13 @@ remotes::install_github("degauss-org/dht")
 
 #### Creating a DeGAUSS container using the DeGAUSS template
 
-`dht::use_degauss_container()` creates all files needed to build a DeGAUSS container.  
+`dht::use_degauss_container()` creates all files needed to build a DeGAUSS container.
 
-See the [DeGAUSS Container Template](https://degauss.org/dht/articles/template-functions.html) vignette for more detailed information on working with these files.
+See the [Developing a New DeGAUSS Container](https://degauss.org/dht/articles/developing-degauss.html) vignette for a step-by-step instruction manual on developing a new [DeGAUSS](https://degauss.org) container using the tools available in `dht`.
    
 #### DeGAUSS helper functions
 
-`dht` also includes a group of helper functions to be used in a DeGAUSS `entrypoint.R` script to make common tasks (e.g., reading in data, checking that needed columns exist and are of the correct type, etc) more efficient and reproducible. 
+`dht` includes a group of helper functions to be used in a DeGAUSS `entrypoint.R` script to make common tasks (e.g., reading in data, checking that needed columns exist and are of the correct type, etc) more efficient and reproducible.
 
 For example, `dht::read_lat_lon_csv()` helps with reading in a csv of geocoded addresses and transforming to an `sf` object of a specified `crs`, while also keeping the raw input data.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 status](https://github.com/degauss-org/dht/workflows/R-CMD-check/badge.svg)](https://github.com/degauss-org/dht/actions)
 <!-- badges: end -->
 
-`dht` (**d**egauss **h**elper **t**ools) is a collection of tools used
-to develop and run [DeGAUSS](https://degauss.org) containers.
+(**d**egauss **h**elper **t**ools) are used to develop and run
+[DeGAUSS](https://degauss.org) containers.
 
 ## Installation
 
@@ -29,13 +29,15 @@ remotes::install_github("degauss-org/dht")
 `dht::use_degauss_container()` creates all files needed to build a
 DeGAUSS container.
 
-See the [DeGAUSS Container
-Template](https://degauss.org/dht/articles/template-functions.html)
-vignette for more detailed information on working with these files.
+See the [Developing a New DeGAUSS
+Container](https://degauss.org/dht/articles/developing-degauss.html)
+vignette for a step-by-step instruction manual on developing a new
+[DeGAUSS](https://degauss.org) container using the tools available in
+`dht`.
 
 #### DeGAUSS helper functions
 
-`dht` also includes a group of helper functions to be used in a DeGAUSS
+`dht` includes a group of helper functions to be used in a DeGAUSS
 `entrypoint.R` script to make common tasks (e.g., reading in data,
 checking that needed columns exist and are of the correct type, etc)
 more efficient and reproducible.

--- a/inst/degauss_Dockerfile
+++ b/inst/degauss_Dockerfile
@@ -1,5 +1,14 @@
 FROM rocker/r-ver:{{{r_version}}}
 
+ENV degauss_name="{{{name}}}"
+ENV degauss_version="{{{version}}}"
+ENV degauss_description="insert short description here that finishes the sentence `This container ...`"
+
+# add labels based on environment variables too
+LABEL "org.degauss.name"="${degauss_name}"
+LABEL "org.degauss.version"="${degauss_version}"
+LABEL "org.degauss.description"="${degauss_description}"
+
 RUN R --quiet -e "install.packages('remotes', repos = c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/focal/latest'))"
 
 RUN R --quiet -e "remotes::install_github('rstudio/renv@{{{renv_version}}}')"

--- a/inst/degauss_entrypoint.R
+++ b/inst/degauss_entrypoint.R
@@ -1,6 +1,6 @@
 #!/usr/local/bin/Rscript
 
-dht::greeting(geomarker_name = "{{{name}}}", version = "{{{version}}}", description = "insert short description here")
+dht::greeting()
 
 dht::qlibrary(dplyr)
 dht::qlibrary(tidyr)
@@ -25,8 +25,4 @@ dht::check_for_column(d$raw_data, "lon", d$raw_data$lon)
 ## add code here to calculate geomarkers
 
 ## merge back on .row after unnesting .rows into .row
-write_geomarker_file(d = d$d,
-                     raw_data = d$raw_data,
-                     filename = opt$filename,
-                     geomarker_name = "{{{name}}}",
-                     version = "{{{version}}}")
+write_geomarker_file(d = d$d, raw_data = d$raw_data, filename = opt$filename)

--- a/man/greeting.Rd
+++ b/man/greeting.Rd
@@ -4,7 +4,11 @@
 \alias{greeting}
 \title{display DeGUASS greeting message in console}
 \usage{
-greeting(geomarker_name, version, description)
+greeting(
+  geomarker_name = Sys.getenv("degauss_name"),
+  version = Sys.getenv("degauss_version"),
+  description = Sys.getenv("degauss_description")
+)
 }
 \arguments{
 \item{geomarker_name}{name of the geomarker, must be the name used in the degauss.org url}
@@ -14,7 +18,10 @@ greeting(geomarker_name, version, description)
 \item{description}{brief description of the container; finishes the sentence "This container..."}
 }
 \description{
-display DeGUASS greeting message in console
+if not supplied as arguments, greeting-specific values
+(geomarker_name, version, description) are read in from the environment variables
+specified in the Dockerfile and made available when running the container;
+these include \code{degauss_name}, \code{degauss_version}, and \code{degauss_description}
 }
 \details{
 greeting message includes name, version, and brief description of container,

--- a/man/use_degauss_container.Rd
+++ b/man/use_degauss_container.Rd
@@ -15,7 +15,7 @@
 \usage{
 use_degauss_container(geomarker = getwd(), version = "0.1.0", ...)
 
-use_degauss_dockerfile(geomarker = getwd(), ...)
+use_degauss_dockerfile(geomarker = getwd(), version, ...)
 
 use_degauss_makefile(geomarker = getwd(), ...)
 

--- a/man/write_geomarker_file.Rd
+++ b/man/write_geomarker_file.Rd
@@ -4,7 +4,13 @@
 \alias{write_geomarker_file}
 \title{write geomarker output to file}
 \usage{
-write_geomarker_file(d, raw_data = NULL, filename, geomarker_name, version)
+write_geomarker_file(
+  d,
+  raw_data = NULL,
+  filename,
+  geomarker_name = Sys.getenv("degauss_name"),
+  version = Sys.getenv("degauss_version")
+)
 }
 \arguments{
 \item{d}{input nest on .row with added geomarker column(s)}
@@ -14,9 +20,11 @@ nest_df = FALSE in read_lat_lon_csv)}
 
 \item{filename}{name of input file, probably opt$filename if inside container}
 
-\item{geomarker_name}{name of the geomarker, must be the name used in the degauss.org url}
+\item{geomarker_name}{name of the geomarker, must be the name used in the degauss.org url;
+defaults to degauss environment variable \code{degauss_name}}
 
-\item{version}{container version number as a character string}
+\item{version}{container version number as a character string; defaults to degauss environment
+variable \code{degauss_version}}
 }
 \value{
 output file is written to working directory

--- a/tests/testthat/test-use_degauss_template.R
+++ b/tests/testthat/test-use_degauss_template.R
@@ -24,7 +24,7 @@ test_that("use_degauss_dockerfile makes a Dockerfile", {
   path <- fs::path_join(c(fs::path_wd(), "test_geomarker"))
   fs::dir_create(path)
   on.exit(fs::dir_delete(path))
-  use_degauss_dockerfile(geomarker = path)
+  use_degauss_dockerfile(geomarker = path, version = "0.1")
   testthat::expect_true(fs::file_exists(fs::path_join(c(path, "Dockerfile"))))
 })
 

--- a/vignettes/developing-degauss.Rmd
+++ b/vignettes/developing-degauss.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Creating a DeGAUSS Container"
+title: "Developing a New DeGAUSS Container"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Creating a DeGAUSS Container}
+  %\VignetteIndexEntry{Developing a New DeGAUSS Container}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/template-functions.Rmd
+++ b/vignettes/template-functions.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "DeGAUSS Container Template"
+title: "Creating a DeGAUSS Container"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{DeGAUSS Container Template}
+  %\VignetteIndexEntry{Creating a DeGAUSS Container}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -13,40 +13,63 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 ```
+The following guide is a step-by-step instruction manual for developing a [DeGAUSS](https://degauss.org) container using tools available in the [`dht` R package](https://degauss.org/dht).
 
-#### Creating all files needed
+### Creating all files needed
 
-Use `dht::use_degauss_container()` to create all of the files needed for a DeGAUSS container.
+Within an empty directory, use `dht::use_degauss_container()` to create all of the files needed for a DeGAUSS container. Note that the name of this initially empty directory will be used as the name of the geomarker in the documentation, code, and image repository; it is a good idea to only use lower case letters and underscores (e.g., `census_block_group`) to comply with container naming conventions.
 
-- Files that **need** to be edited:
-  - `entrypoint.R` (contains R code to be run in the container)
-  - `README.md` (software documentation and example instructions)
-
-- Files that **may** need to be edited (if any files need to be included in the container):
-  - `Dockerfile` (file used to build container)
-  - `.dockerignore`
-
-- Files that **do not** need to be edited:
+- Most of the added files will *usually* not need to be edited:
   - `Makefile` (see below for `Make` targets)
   - `test/my_address_file_geocoded.csv` (test input data file)
   - `LICENSE.md` (GPL license)
   - `.github/workflows/build-deply.yaml` (GitHub Actions continuous integration)
+  - `.dockerignore` (edit to include files other than entrypoint.R in the image)
+
+- Files that **need** to be edited:
+  - `Dockerfile` (`degauss_description` environment variable)
+  - `entrypoint.R` (contains R code to be run in the container)
+  - `README.md` (software documentation and example instructions)
+  
+### Editing files to add R code and documentation
+
+#### Documentation
+
+Add any geomarker information and additional details to `README.md`. Make sure that the version in the example call matches the version of the latest released container. 
+
+Environment variables (`degauss_name`, `degauss_version`, and `degauss_description`) are defined within the `Dockerfile` so that they will be available to R code running from inside the container. All but `degauss_description` are automatically defined and this value needs to be edited from 
+
+```sh
+ENV degauss_description="insert short description here that finishes the sentence `This container ...`"
+```
+
+to something specific, like
+
+```sh
+ENV degauss_description="assigns census block group for different vintages of census geographies"
+```
+
+In the future, the environment variable `degauss_version` can be edited in the `Dockerfile` and R code in the container can use it for greetings, writing output files, and other operations that depend on the current version (or name or description).
+
 
 #### Using R code and data files inside the container
 
 Edit `entrypoint.R` by replacing the example R code with R code that
-completes the specific task to be performed by the container, then run
-`renv::init()` to initiate the `renv` framework and create `renv.lock`.
-Add any geomarker information and addtional details to `README.md`.
+completes the specific task to be performed by the container.
 
-If the container requires any other files (e.g., `.rds` datafiles), edit
+When ready to build the container, run
+`renv::init()` to initiate the `renv` framework and create `renv.lock`. Subsequent builds can update `renv.lock` by using `renv::snapshot()`.
+
+### Including files inside the container
+
+By default, the container will copy in `entrypoint.R` and `renv.lock` for use at runtime and ignore anything else in the working directory to automatically speed up build times and keep containers smaller in size. If the container requires any other files (e.g., `.rds` datafiles), edit
 `Dockerfile` and `.dockerignore` so that the files are copied to the
 container and not ignored by Docker. For example, if we want to use
 `geomarker_data.rds`, we would make the following changes in `Dockerfile`:
 
 ```sh
     COPY entrypoint.R .
-	COPY geomarker_data.rd
+	COPY geomarker_data.rds    # copy .rds file from host to container when building
 ```
 
 and in `.dockerignore`:
@@ -61,14 +84,15 @@ and in `.dockerignore`:
     !/geomarker_data.rds      # make sure the .rds file is not ignored
 ```
 
-The rest of the DeGAUSS template files come ready-to-use and do not need
-to be edited.
+### Tests
 
-#### Using `make` for interactive development
+A `test` directory is added with an example geocoded address file (`test/my_address_file_geocoded.csv`) and is useful for interactive development and automated testing (see below).
+
+### Using `make` for interactive development
 
 The `Makefile` defines several useful `make` targets that can be useful when locally developing and testing:
 
 - `make build` will build the current DeGAUSS image and name it
 - `make test` will run the container on the included example geocoded CSV file
-- `make shell` will run a DeGAUSS command, but start an interactive shell for debugging
+- `make shell` will run a DeGAUSS command, but start an interactive shell inside the container for debugging
 - `make clean` is equivalent to `docker system prune -f`, which cleans up any stopped containers or dangling image layers


### PR DESCRIPTION
- `dht::greeting` and `dht::write_geomarker_file` now default to using degauss environment variables
- added `ENV` commands in Dockerfile template to define degauss environment variables
- expanded vignette on developing a new DeGAUSS container