### PR TITLE
fix check_date problem when data was already type Date; closes #70

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dht
 Title: A Collection of Functions to Assist Building DeGAUSS Containers
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person(given = "Erika",
            family = "Rasnick",

--- a/man/check_dates.Rd
+++ b/man/check_dates.Rd
@@ -18,15 +18,14 @@ reformatted vector of dates, or an error if dates could not be reformatted
 check format of dates from DeGAUSS container input file
 }
 \details{
-ISO formatted dates (e.g., "\%Y-\%m-\%d" or 2021-01-01) will stay the same
-U.S. standard slash formatted dates (common to Microsoft Excel; e.g., "\%m/\%d/\%y" or 1/1/21)
+ISO formatted dates (i.e., "\%Y-\%m-\%d" or YYYY-MM-DD) will stay the same
+U.S. standard slash formatted dates (common to Microsoft Excel;
+e.g., "\%m/\%d/\%y" or MM/DD/YY, "\%m/\%d/\%Y" or MM/DD/YYYY)
 will be reformatted to ISO format
-Any input not recognized by one of the two above formats will cause an error and
-the user will be instructed to manually reformat their dates.
+Any unrecognized input will cause an error and
+the user will be instructed to reformat their dates.
 }
 \examples{
-\dontrun{
 date <- c("1/1/21", "1/2/21", "1/3/21")
 check_dates(date)
-}
 }

--- a/tests/testthat/test-check_dates.R
+++ b/tests/testthat/test-check_dates.R
@@ -1,26 +1,37 @@
-test_that("check slash dates", {
+test_that("slash dates work", {
   expect_identical(
     check_dates(c("1/1/21", "1/2/21", "1/3/21")),
     as.Date(c("2021-01-01", "2021-01-02", "2021-01-03"))
   )
 })
 
-test_that("slash dates with four digit year error", {
-  expect_error(
-    check_dates(c("12/15/2020", "8/4/1998", "06/09/1995"))
+test_that("slash dates with four digit year work", {
+  expect_identical(
+    check_dates(c("1/1/2021", "1/2/2021", "1/3/2021")),
+    as.Date(c("2021-01-01", "2021-01-02", "2021-01-03"))
   )
 })
 
-test_that("check ISO dates", {
+test_that("dash dates work", {
   expect_identical(
     check_dates(c("2021-01-01", "2021-01-02", "2021-01-03")),
     as.Date(c("2021-01-01", "2021-01-02", "2021-01-03"))
   )
 })
 
-test_that("check ambiguous dates", {
+test_that("date formatted work", {
+  expect_identical(
+    check_dates(as.Date(c("2021-01-01", "2021-01-02", "2021-01-03"))),
+    as.Date(c("2021-01-01", "2021-01-02", "2021-01-03"))
+  )
+})
+
+test_that("nonsense/ambiguous dates error", {
   expect_error(
     check_dates(c("jan 1", "jan 2", "jan 3"))
+  )
+  expect_error(
+    check_dates(c("10/14/20008", "10/14/200"))
   )
 })
 
@@ -60,20 +71,35 @@ test_that("check end date after start date if end = start", {
   )
 })
 
-test_that("missing dates (blank) are not allowed", {
-  expect_error(
-    check_dates(c("12/15/2020", "", "06/09/1995"))
-  )
+test_that("missing dates cause error", {
+  expect_error(check_dates(as.Date(c("2020-11-05", NA, "2021-01-01"))))
+  expect_error(check_dates(c("2020-11-05", NA, "2021-01-01")))
+  expect_error(check_dates(c("2020-11-05", " ", "2021-01-01")))
+  expect_error(check_dates(c("2020-11-05", "", "2021-01-01")))
+  expect_error(check_dates((c("11/5/20", NA, "01/1/21"))))
+  expect_error(check_dates((c("11/5/20", " ", "01/1/21"))))
+  expect_error(check_dates((c("11/5/20", "", "01/1/21"))))
 })
 
-test_that("missing dates (blank space) are not allowed", {
-  expect_error(
-    check_dates(c("12/15/2020", " ", "06/09/1995"))
+test_that("missing dates work, if allowed", {
+  expect_identical(
+    check_dates(as.Date(c("2020-11-05", NA, "2021-01-01")), allow_missing = TRUE),
+    as.Date(c("2020-11-05", NA, "2021-01-01"))
   )
-})
-
-test_that("missing dates (NA) are not allowed", {
-  expect_error(
-    check_dates(c("12/15/2020", NA, "06/09/1995"))
+  expect_identical(
+    check_dates(c("2020-11-05", NA, "2021-01-01"), allow_missing = TRUE),
+    as.Date(c("2020-11-05", NA, "2021-01-01"))
+  )
+  expect_identical(
+    check_dates(c("11/5/20", NA, "1/1/21"), allow_missing = TRUE),
+    as.Date(c("2020-11-05", NA, "2021-01-01"))
+  )
+  expect_identical(
+    check_dates(c("12/15/20", "", "06/09/95"), allow_missing = TRUE),
+    as.Date(c("2020-12-15", NA, "1995-06-09"))
+  )
+  expect_identical(
+    check_dates(c("12/15/20", " ", "06/09/95"), allow_missing = TRUE),
+    as.Date(c("2020-12-15", NA, "1995-06-09"))
   )
 })


### PR DESCRIPTION
This also allows the ability to read in "mm/dd/yyyy" dates (in addition to "mm/dd/yy" and "yyyy-mm-dd").